### PR TITLE
Class of wallc-s and keyfob to zwavecontroller

### DIFF
--- a/app.json
+++ b/app.json
@@ -380,7 +380,7 @@
 				5
 			]
 		},
-		"class": "light",
+		"class": "zwavecontroller",
 		"capabilities": [
 			"measure_battery"
 		],
@@ -754,7 +754,7 @@
 				5
 			]
 		},
-		"class": "light",
+		"class": "zwavecontroller",
 		"capabilities": [
 			"measure_battery"
 		],
@@ -1127,7 +1127,7 @@
 				5
 			]
 		},
-		"class": "light",
+		"class": "zwavecontroller",
 		"capabilities": [
 			"measure_battery"
 		],


### PR DESCRIPTION
Changed the class for the WALLC_S, WALLC_2 and Keyfob to
"zwavecontroller"  For battery status
"Light" was the incorrect class obviously